### PR TITLE
client_max_body_size 隨人管理，mài tī tsia限制。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginxproxy/nginx-proxy
+RUN { \
+      echo 'server_tokens off;'; \
+      echo 'client_max_body_size 1G;'; \
+    } > /etc/nginx/conf.d/my_proxy.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   nginx-proxy:
-    image: nginxproxy/nginx-proxy
+    build: .
     labels:
       - com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy
     ports:


### PR DESCRIPTION
## 變更原因
因為教典後台欲傳音檔，client_max_body_size 預設1m siunn細。
因為ta̍k-ê專案攏有ka-tī ê nginx，決定client_max_body_size 隨專案nginx管理，mài tī ZuGi tsia限制。

## 變更時間
2023.5.2～2023.5.4

## 需求
ZuGi mài 限制 client_max_body_size，設做1G。
## 可能影響
### 機密

無機密問題

### 完整

無

### 可用

若專案client_max_body_size 設定siunn大，可能會hōo歹人post大檔案，浪費網路。這風險低

## 解決做法Github連結
這PR。

## 未來規劃

Bô。

### 審查意見