### PR TITLE
配合gradio 5.0，response header較大。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,7 @@ RUN { \
       echo 'server_tokens off;'; \
       echo 'client_max_body_size 1G;'; \
       echo 'proxy_read_timeout 600s;'; \
+      echo 'proxy_busy_buffers_size 64k;'; \
+      echo 'proxy_buffers 4 64k;'; \
+      echo 'proxy_buffer_size 32k;'; \
     } > /etc/nginx/conf.d/my_proxy.conf


### PR DESCRIPTION
升gradio 4.0-> 5.0，nginx出現`upstream sent too big header while reading response header from upstream`

所以調整設定hōo buffer較大--leh