### PR TITLE
ipV6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,10 @@ services:
     labels:
       - com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy
     ports:
-      - 80:80
-      - 443:443
+      - "80:80"
+      - "443:443"
+      - "[::]:80:80"
+      - "[::]:443:443"
     volumes:
       - cert_data:/etc/nginx/certs
       - vhost_data:/etc/nginx/vhost.d


### PR DESCRIPTION
事由：

- 有民眾學術網路IPv6連袂著教典。（事故單編號：2025-200）

解法：

- https://stackoverflow.com/a/74725573/3640653

變更影響：

- 原本僅支援IPv4 443 port和80 port；現加上支援IPv6 443 port和80 port。