### PR TITLE
Remove DEFAULT_EMAIL from nginx environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ docker-compose up -d
 
 #### 做法
 用[acme-companion](https://github.com/nginx-proxy/acme-companion)，設定在`docker-compse.yml`。
-愛設定`DEFAULT_EMAIL`，憑證過期會通知。
 
 ### 其他文件
 苗栗話用个virtual host，完整英文[文件](https://github.com/nginx-proxy/acme-companion#readme)。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,6 @@ services:
       - vhost_data:/etc/nginx/vhost.d
       - html_data:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    environment:
-      DEFAULT_EMAIL: ${DEFAULT_EMAIL}
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
## 事由

https://letsencrypt.org/2025/01/22/ending-expiration-emails
> Ending Support for Expiration Notification Emails
> By Josh Aas · January 22, 2025 

## 變更影響

UX: 無。
Security: Docker compose移除無效的環境變數DEFAULT_EMAIL。
Maintenance: 無。