### PR TITLE
因為TWCC 無支援IPv6, Remove IPv6 port mappings from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - "[::]:80:80"
-      - "[::]:443:443"
     volumes:
       - cert_data:/etc/nginx/certs
       - vhost_data:/etc/nginx/vhost.d


### PR DESCRIPTION
Removed IPv6 port mappings for HTTP and HTTPS.